### PR TITLE
feat(auth): implement TokenManager and API client

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,9 @@ export default [
         setTimeout: "readonly",
         clearTimeout: "readonly",
         URL: "readonly",
+        URLSearchParams: "readonly",
+        fetch: "readonly",
+        globalThis: "readonly",
       },
     },
     rules: {

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,8 +1,11 @@
 /**
  * HTTP client for the Cuti-E Admin API.
  *
- * Wraps fetch with automatic OAuth2 token injection and error handling.
+ * Wraps fetch with automatic OAuth2 token injection, 401 retry, and error handling.
  */
+
+import { CutiEAPIError } from "../utils/errors.js";
+
 export class CutiEClient {
   #apiUrl;
   #tokenManager;
@@ -19,13 +22,17 @@ export class CutiEClient {
 
   /**
    * Make an authenticated GET request.
-   * @param {string} path - API path (e.g., '/v1/conversations')
-   * @param {URLSearchParams} [params] - Query parameters
+   * @param {string} path - API path (e.g., "/v1/conversations")
+   * @param {Object} [params] - Query parameters as key-value pairs
    * @returns {Promise<Object>} Parsed JSON response
    */
-  async get(_path, _params) {
-    // TODO: Implement - see issue #2
-    throw new Error("CutiEClient not yet implemented - see issue #2");
+  async get(path, params) {
+    let url = `${this.#apiUrl}${path}`;
+    if (params && Object.keys(params).length > 0) {
+      const qs = new URLSearchParams(params).toString();
+      url += `?${qs}`;
+    }
+    return this.#request(url, { method: "GET" });
   }
 
   /**
@@ -34,9 +41,12 @@ export class CutiEClient {
    * @param {Object} body - Request body (JSON)
    * @returns {Promise<Object>} Parsed JSON response
    */
-  async post(_path, _body) {
-    // TODO: Implement - see issue #2
-    throw new Error("CutiEClient not yet implemented - see issue #2");
+  async post(path, body) {
+    return this.#request(`${this.#apiUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
   }
 
   /**
@@ -45,9 +55,26 @@ export class CutiEClient {
    * @param {Object} body - Request body (JSON)
    * @returns {Promise<Object>} Parsed JSON response
    */
-  async put(_path, _body) {
-    // TODO: Implement - see issue #2
-    throw new Error("CutiEClient not yet implemented - see issue #2");
+  async put(path, body) {
+    return this.#request(`${this.#apiUrl}${path}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  /**
+   * Make an authenticated PATCH request.
+   * @param {string} path - API path
+   * @param {Object} body - Request body (JSON)
+   * @returns {Promise<Object>} Parsed JSON response
+   */
+  async patch(path, body) {
+    return this.#request(`${this.#apiUrl}${path}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
   }
 
   /**
@@ -55,8 +82,53 @@ export class CutiEClient {
    * @param {string} path - API path
    * @returns {Promise<Object>} Parsed JSON response
    */
-  async delete(_path) {
-    // TODO: Implement - see issue #2
-    throw new Error("CutiEClient not yet implemented - see issue #2");
+  async delete(path) {
+    return this.#request(`${this.#apiUrl}${path}`, { method: "DELETE" });
+  }
+
+  /**
+   * Internal request method with token injection and 401 retry.
+   */
+  async #request(url, options, isRetry = false) {
+    const token = await this.#tokenManager.getToken();
+    const headers = {
+      ...options.headers,
+      Authorization: `Bearer ${token}`,
+    };
+
+    const res = await fetch(url, { ...options, headers });
+
+    // Retry once on 401 with a fresh token
+    if (res.status === 401 && !isRetry) {
+      await this.#tokenManager.forceRefresh();
+      return this.#request(url, options, true);
+    }
+
+    if (!res.ok) {
+      let body;
+      const contentType = res.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        body = await res.json().catch(() => undefined);
+      } else {
+        const text = await res.text().catch(() => "");
+        body = text || undefined;
+      }
+      throw new CutiEAPIError(
+        body?.error || `Request failed: ${res.status}`,
+        res.status,
+        body
+      );
+    }
+
+    // Handle empty responses (204 No Content)
+    if (res.status === 204) {
+      return null;
+    }
+
+    const contentType = res.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      return res.json();
+    }
+    return res.text();
   }
 }

--- a/src/auth/token-manager.js
+++ b/src/auth/token-manager.js
@@ -1,21 +1,26 @@
 /**
  * OAuth2 Client Credentials token manager.
  *
- * Handles token acquisition and auto-refresh for the Cuti-E API.
- * Tokens are refreshed automatically when they expire or are close to expiry.
+ * Handles token acquisition, caching, and auto-refresh for the Cuti-E API.
+ * Uses a promise lock to prevent concurrent refresh requests.
  */
+
+import { AuthError } from "../utils/errors.js";
+
 export class TokenManager {
   #apiUrl;
   #clientId;
   #clientSecret;
   #accessToken = null;
+  #refreshToken = null;
   #expiresAt = 0;
+  #refreshPromise = null;
 
   /**
    * @param {Object} config
-   * @param {string} config.apiUrl - Base API URL
-   * @param {string} config.clientId - OAuth2 client ID
-   * @param {string} config.clientSecret - OAuth2 client secret
+   * @param {string} config.apiUrl - Base API URL (e.g., "https://api.cutie.town")
+   * @param {string} config.clientId - OAuth2 client ID (cutie_ci_...)
+   * @param {string} config.clientSecret - OAuth2 client secret (cutie_cs_...)
    */
   constructor({ apiUrl, clientId, clientSecret }) {
     this.#apiUrl = apiUrl;
@@ -25,21 +30,116 @@ export class TokenManager {
 
   /**
    * Get a valid access token, refreshing if needed.
+   * Uses a promise lock so concurrent callers share one refresh request.
    * @returns {Promise<string>} Valid access token
    */
   async getToken() {
-    // Refresh if token is missing or expires within 30 seconds
-    if (!this.#accessToken || Date.now() >= this.#expiresAt - 30_000) {
-      await this.#fetchToken();
+    if (this.#accessToken && Date.now() < this.#expiresAt - 60_000) {
+      return this.#accessToken;
+    }
+
+    // Use lock to prevent concurrent refreshes
+    if (this.#refreshPromise) {
+      await this.#refreshPromise;
+      return this.#accessToken;
+    }
+
+    this.#refreshPromise = this.#refresh();
+    try {
+      await this.#refreshPromise;
+    } finally {
+      this.#refreshPromise = null;
     }
     return this.#accessToken;
   }
 
-  async #fetchToken() {
-    // TODO: Implement OAuth2 client_credentials flow
-    // POST {apiUrl}/oauth/token
-    // Body: grant_type=client_credentials&client_id=...&client_secret=...
-    // Response: { access_token, expires_in, token_type }
-    throw new Error("TokenManager not yet implemented - see issue #2");
+  /**
+   * Force a token refresh (called on 401).
+   * @returns {Promise<string>} New access token
+   */
+  async forceRefresh() {
+    if (this.#refreshPromise) {
+      await this.#refreshPromise;
+      return this.#accessToken;
+    }
+
+    this.#refreshPromise = this.#refresh();
+    try {
+      await this.#refreshPromise;
+    } finally {
+      this.#refreshPromise = null;
+    }
+    return this.#accessToken;
+  }
+
+  /**
+   * Clear all cached tokens.
+   */
+  clear() {
+    this.#accessToken = null;
+    this.#refreshToken = null;
+    this.#expiresAt = 0;
+    this.#refreshPromise = null;
+  }
+
+  async #refresh() {
+    // Try refresh token first if we have one
+    if (this.#refreshToken) {
+      try {
+        await this.#exchangeRefreshToken();
+        return;
+      } catch {
+        // Refresh failed (revoked, expired), fall through to client_credentials
+        this.clear();
+      }
+    }
+
+    await this.#exchangeClientCredentials();
+  }
+
+  async #exchangeClientCredentials() {
+    const res = await fetch(`${this.#apiUrl}/v1/auth/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "client_credentials",
+        client_id: this.#clientId,
+        client_secret: this.#clientSecret,
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new AuthError(
+        `OAuth2 client_credentials failed (${res.status}): ${text}`
+      );
+    }
+
+    const data = await res.json();
+    this.#storeTokens(data);
+  }
+
+  async #exchangeRefreshToken() {
+    const res = await fetch(`${this.#apiUrl}/v1/auth/oauth/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: this.#refreshToken,
+      }),
+    });
+
+    if (!res.ok) {
+      throw new AuthError(`Token refresh failed (${res.status})`);
+    }
+
+    const data = await res.json();
+    this.#storeTokens(data);
+  }
+
+  #storeTokens(data) {
+    this.#accessToken = data.access_token;
+    this.#refreshToken = data.refresh_token;
+    this.#expiresAt = Date.now() + data.expires_in * 1000;
   }
 }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,5 +1,5 @@
 /**
- * Custom error types for admin-mcp.
+ * Custom error types and MCP response formatters for admin-mcp.
  */
 
 export class CutiEAPIError extends Error {
@@ -21,4 +21,29 @@ export class AuthError extends Error {
     super(message);
     this.name = "AuthError";
   }
+}
+
+/**
+ * Format an error into an MCP tool response.
+ * @param {Error} error
+ * @returns {{ content: Array<{type: string, text: string}>, isError: true }}
+ */
+export function formatError(error) {
+  return {
+    content: [{ type: "text", text: `Error: ${error.message}` }],
+    isError: true,
+  };
+}
+
+/**
+ * Format data into a successful MCP tool response.
+ * @param {*} data
+ * @returns {{ content: Array<{type: string, text: string}> }}
+ */
+export function formatSuccess(data) {
+  return {
+    content: [
+      { type: "text", text: JSON.stringify(data, null, 2) },
+    ],
+  };
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CutiEClient } from "../src/api/client.js";
+import { CutiEAPIError } from "../src/utils/errors.js";
+
+const API_URL = "https://api.test.com";
+
+function createMockTokenManager() {
+  return {
+    getToken: vi.fn().mockResolvedValue("cutie_at_test_token"),
+    forceRefresh: vi.fn().mockResolvedValue("cutie_at_refreshed_token"),
+  };
+}
+
+// Headers as a Map-like with .get()
+function createHeaders(entries) {
+  const map = new Map(entries);
+  return { get: (key) => map.get(key) || null };
+}
+
+function mockResponse(status, body, contentType = "application/json") {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: createHeaders([["content-type", contentType]]),
+    json: () => Promise.resolve(typeof body === "object" ? body : JSON.parse(body)),
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  };
+}
+
+describe("CutiEClient", () => {
+  let client;
+  let tokenManager;
+
+  beforeEach(() => {
+    tokenManager = createMockTokenManager();
+    client = new CutiEClient({ apiUrl: API_URL, tokenManager });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("Authorization header", () => {
+    it("adds Bearer token to all requests", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { data: "test" })
+      );
+
+      await client.get("/v1/conversations");
+
+      const [, options] = globalThis.fetch.mock.calls[0];
+      expect(options.headers.Authorization).toBe("Bearer cutie_at_test_token");
+    });
+  });
+
+  describe("GET requests", () => {
+    it("makes GET request to correct URL", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { conversations: [] })
+      );
+
+      const result = await client.get("/v1/conversations");
+
+      expect(globalThis.fetch).toHaveBeenCalledOnce();
+      const [url, options] = globalThis.fetch.mock.calls[0];
+      expect(url).toBe(`${API_URL}/v1/conversations`);
+      expect(options.method).toBe("GET");
+      expect(result).toEqual({ conversations: [] });
+    });
+
+    it("appends query params to URL", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { conversations: [] })
+      );
+
+      await client.get("/v1/conversations", { status: "open", limit: "10" });
+
+      const [url] = globalThis.fetch.mock.calls[0];
+      expect(url).toContain("status=open");
+      expect(url).toContain("limit=10");
+    });
+
+    it("skips query params when empty", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { data: [] })
+      );
+
+      await client.get("/v1/conversations", {});
+
+      const [url] = globalThis.fetch.mock.calls[0];
+      expect(url).toBe(`${API_URL}/v1/conversations`);
+    });
+  });
+
+  describe("POST requests", () => {
+    it("sends JSON body with Content-Type header", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { message_id: "msg_123" })
+      );
+
+      const body = { conversation_id: "conv_1", message: "Hello" };
+      const result = await client.post("/v1/conversations/conv_1/messages", body);
+
+      const [, options] = globalThis.fetch.mock.calls[0];
+      expect(options.method).toBe("POST");
+      expect(options.headers["Content-Type"]).toBe("application/json");
+      expect(JSON.parse(options.body)).toEqual(body);
+      expect(result).toEqual({ message_id: "msg_123" });
+    });
+  });
+
+  describe("PUT requests", () => {
+    it("sends PUT with JSON body", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { updated: true })
+      );
+
+      await client.put("/v1/conversations/conv_1", { status: "resolved" });
+
+      const [, options] = globalThis.fetch.mock.calls[0];
+      expect(options.method).toBe("PUT");
+      expect(JSON.parse(options.body)).toEqual({ status: "resolved" });
+    });
+  });
+
+  describe("PATCH requests", () => {
+    it("sends PATCH with JSON body", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { updated: true })
+      );
+
+      await client.patch("/v1/conversations/conv_1", { priority: "high" });
+
+      const [, options] = globalThis.fetch.mock.calls[0];
+      expect(options.method).toBe("PATCH");
+      expect(JSON.parse(options.body)).toEqual({ priority: "high" });
+    });
+  });
+
+  describe("DELETE requests", () => {
+    it("sends DELETE request", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(204, "", "text/plain")
+      );
+
+      const result = await client.delete("/v1/tags/tag_1");
+
+      const [, options] = globalThis.fetch.mock.calls[0];
+      expect(options.method).toBe("DELETE");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("401 retry", () => {
+    it("retries once on 401 with a fresh token", async () => {
+      let callCount = 0;
+      globalThis.fetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve(
+            mockResponse(401, { error: "Token expired" })
+          );
+        }
+        return Promise.resolve(
+          mockResponse(200, { data: "success" })
+        );
+      });
+
+      const result = await client.get("/v1/conversations");
+
+      expect(result).toEqual({ data: "success" });
+      expect(tokenManager.forceRefresh).toHaveBeenCalledOnce();
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws on second 401 (no infinite retry)", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(401, { error: "Invalid token" })
+      );
+
+      await expect(client.get("/v1/conversations")).rejects.toThrow(CutiEAPIError);
+      // First call + one retry = 2 fetch calls
+      expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("throws CutiEAPIError on non-401 errors", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(404, { error: "Conversation not found" })
+      );
+
+      try {
+        await client.get("/v1/conversations/nonexistent");
+        expect.unreachable("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(CutiEAPIError);
+        expect(err.statusCode).toBe(404);
+        expect(err.message).toBe("Conversation not found");
+      }
+    });
+
+    it("handles non-JSON error responses", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(500, "Internal Server Error", "text/plain")
+      );
+
+      try {
+        await client.get("/v1/conversations");
+        expect.unreachable("Should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(CutiEAPIError);
+        expect(err.statusCode).toBe(500);
+      }
+    });
+
+    it("handles JSON responses", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, { items: [1, 2, 3] })
+      );
+
+      const result = await client.get("/v1/items");
+      expect(result).toEqual({ items: [1, 2, 3] });
+    });
+
+    it("handles non-JSON success responses", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        mockResponse(200, "OK", "text/plain")
+      );
+
+      const result = await client.get("/v1/health");
+      expect(result).toBe("OK");
+    });
+  });
+});

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  CutiEAPIError,
+  AuthError,
+  formatError,
+  formatSuccess,
+} from "../src/utils/errors.js";
+
+describe("CutiEAPIError", () => {
+  it("stores statusCode and body", () => {
+    const err = new CutiEAPIError("Not found", 404, { detail: "missing" });
+    expect(err.message).toBe("Not found");
+    expect(err.statusCode).toBe(404);
+    expect(err.body).toEqual({ detail: "missing" });
+    expect(err.name).toBe("CutiEAPIError");
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("AuthError", () => {
+  it("has correct name", () => {
+    const err = new AuthError("Token expired");
+    expect(err.message).toBe("Token expired");
+    expect(err.name).toBe("AuthError");
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe("formatError", () => {
+  it("returns MCP error response format", () => {
+    const err = new Error("Something broke");
+    const result = formatError(err);
+
+    expect(result).toEqual({
+      content: [{ type: "text", text: "Error: Something broke" }],
+      isError: true,
+    });
+  });
+
+  it("works with CutiEAPIError", () => {
+    const err = new CutiEAPIError("Not found", 404);
+    const result = formatError(err);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("Error: Not found");
+  });
+});
+
+describe("formatSuccess", () => {
+  it("returns MCP success response with JSON data", () => {
+    const data = { conversations: [{ id: "conv_1" }] };
+    const result = formatSuccess(data);
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual(data);
+  });
+
+  it("pretty-prints JSON with 2-space indent", () => {
+    const result = formatSuccess({ a: 1 });
+    expect(result.content[0].text).toBe('{\n  "a": 1\n}');
+  });
+});

--- a/test/token-manager.test.js
+++ b/test/token-manager.test.js
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TokenManager } from "../src/auth/token-manager.js";
+import { AuthError } from "../src/utils/errors.js";
+
+const API_URL = "https://api.test.com";
+const CLIENT_ID = "cutie_ci_test123";
+const CLIENT_SECRET = "cutie_cs_secret456";
+
+function makeTokenResponse(overrides = {}) {
+  return {
+    access_token: overrides.access_token || "cutie_at_abc123",
+    refresh_token: overrides.refresh_token || "cutie_rt_xyz789",
+    token_type: "Bearer",
+    expires_in: overrides.expires_in ?? 3600,
+    scopes: ["conversations:read", "conversations:write"],
+  };
+}
+
+function mockFetchOk(data) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  });
+}
+
+function mockFetchError(status, body) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  });
+}
+
+describe("TokenManager", () => {
+  let tm;
+
+  beforeEach(() => {
+    tm = new TokenManager({
+      apiUrl: API_URL,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exchanges client credentials on first getToken call", async () => {
+    const tokenData = makeTokenResponse();
+    globalThis.fetch = mockFetchOk(tokenData);
+
+    const token = await tm.getToken();
+
+    expect(token).toBe("cutie_at_abc123");
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+
+    const [url, options] = globalThis.fetch.mock.calls[0];
+    expect(url).toBe(`${API_URL}/v1/auth/oauth/token`);
+    expect(options.method).toBe("POST");
+    expect(JSON.parse(options.body)).toEqual({
+      grant_type: "client_credentials",
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    });
+  });
+
+  it("returns cached token on subsequent calls", async () => {
+    const tokenData = makeTokenResponse({ expires_in: 7200 });
+    globalThis.fetch = mockFetchOk(tokenData);
+
+    const token1 = await tm.getToken();
+    const token2 = await tm.getToken();
+
+    expect(token1).toBe(token2);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("refreshes when token is within 60s of expiry", async () => {
+    // First call: token that expires in 30 seconds (within 60s threshold)
+    const shortLived = makeTokenResponse({
+      access_token: "cutie_at_short",
+      refresh_token: "cutie_rt_short",
+      expires_in: 30,
+    });
+    globalThis.fetch = mockFetchOk(shortLived);
+    await tm.getToken();
+
+    // Second call should trigger refresh since token expires within 60s
+    const refreshed = makeTokenResponse({
+      access_token: "cutie_at_refreshed",
+      refresh_token: "cutie_rt_refreshed2",
+    });
+    globalThis.fetch = mockFetchOk(refreshed);
+
+    const token = await tm.getToken();
+    expect(token).toBe("cutie_at_refreshed");
+
+    // Should have used refresh_token grant
+    const body = JSON.parse(globalThis.fetch.mock.calls[0][1].body);
+    expect(body.grant_type).toBe("refresh_token");
+    expect(body.refresh_token).toBe("cutie_rt_short");
+  });
+
+  it("concurrent calls share one refresh request", async () => {
+    let resolveCount = 0;
+    const tokenData = makeTokenResponse();
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      resolveCount++;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(tokenData),
+      });
+    });
+
+    // Fire 5 concurrent getToken calls
+    const results = await Promise.all([
+      tm.getToken(),
+      tm.getToken(),
+      tm.getToken(),
+      tm.getToken(),
+      tm.getToken(),
+    ]);
+
+    // All should get the same token
+    for (const t of results) {
+      expect(t).toBe("cutie_at_abc123");
+    }
+
+    // But only 1 fetch call should have been made
+    expect(resolveCount).toBe(1);
+  });
+
+  it("falls back to client_credentials when refresh fails", async () => {
+    // First call: get initial tokens
+    const initial = makeTokenResponse({
+      access_token: "cutie_at_initial",
+      refresh_token: "cutie_rt_initial",
+      expires_in: 10, // will expire soon
+    });
+    globalThis.fetch = mockFetchOk(initial);
+    await tm.getToken();
+
+    // Second call: refresh fails (401), then client_credentials succeeds
+    let callCount = 0;
+    const fallback = makeTokenResponse({ access_token: "cutie_at_fallback" });
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        // refresh_token attempt fails
+        return Promise.resolve({
+          ok: false,
+          status: 401,
+          text: () => Promise.resolve("Invalid refresh token"),
+        });
+      }
+      // client_credentials succeeds
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(fallback),
+      });
+    });
+
+    const token = await tm.getToken();
+    expect(token).toBe("cutie_at_fallback");
+    expect(callCount).toBe(2);
+
+    // Verify second call was client_credentials
+    const body = JSON.parse(globalThis.fetch.mock.calls[1][1].body);
+    expect(body.grant_type).toBe("client_credentials");
+  });
+
+  it("throws AuthError on invalid credentials", async () => {
+    globalThis.fetch = mockFetchError(401, "Invalid client credentials");
+
+    await expect(tm.getToken()).rejects.toThrow(AuthError);
+    await expect(tm.getToken()).rejects.toThrow("client_credentials failed");
+  });
+
+  it("forceRefresh gets a new token", async () => {
+    const initial = makeTokenResponse({ access_token: "cutie_at_old", expires_in: 7200 });
+    globalThis.fetch = mockFetchOk(initial);
+    await tm.getToken();
+
+    const refreshed = makeTokenResponse({ access_token: "cutie_at_new" });
+    globalThis.fetch = mockFetchOk(refreshed);
+
+    const token = await tm.forceRefresh();
+    expect(token).toBe("cutie_at_new");
+  });
+
+  it("clear removes all cached tokens", async () => {
+    const tokenData = makeTokenResponse();
+    globalThis.fetch = mockFetchOk(tokenData);
+    await tm.getToken();
+
+    tm.clear();
+
+    // Should need to fetch again
+    const newData = makeTokenResponse({ access_token: "cutie_at_after_clear" });
+    globalThis.fetch = mockFetchOk(newData);
+
+    const token = await tm.getToken();
+    expect(token).toBe("cutie_at_after_clear");
+  });
+});


### PR DESCRIPTION
## Summary
- Implements OAuth2 `client_credentials` token manager with refresh token rotation, 60s proactive refresh, and promise-based concurrency lock to prevent parallel refresh storms
- Implements HTTP client with automatic Bearer token injection, single 401 retry (force refresh then retry), and JSON/text response parsing
- Adds `formatError`/`formatSuccess` helpers for MCP-compatible tool responses
- 28 new tests (41 total), all passing

### TokenManager (`src/auth/token-manager.js`)
- `getToken()` → returns cached token or exchanges credentials
- `forceRefresh()` → forces a new token (used by client on 401)
- `clear()` → wipes cached tokens
- Refresh token rotation: uses `refresh_token` grant first, falls back to `client_credentials` on failure
- Promise lock: concurrent `getToken()` calls share a single fetch

### CutiEClient (`src/api/client.js`)
- `get(path, params?)`, `post(path, body)`, `put(path, body)`, `patch(path, body)`, `delete(path)`
- Auto-retries once on 401, throws `CutiEAPIError` on all other failures
- Handles JSON responses, text responses, and 204 No Content

### Error utilities (`src/utils/errors.js`)
- `formatError(error)` → `{ content: [{type: "text", text: "Error: ..."}], isError: true }`
- `formatSuccess(data)` → `{ content: [{type: "text", text: "..."}] }`

Closes #2

## Test plan
- [x] TokenManager exchanges client_credentials on first call
- [x] TokenManager caches tokens and returns cached on subsequent calls
- [x] TokenManager refreshes when token is within 60s of expiry
- [x] Concurrent getToken() calls share one refresh (lock test)
- [x] TokenManager falls back to client_credentials when refresh fails
- [x] TokenManager throws AuthError on invalid credentials
- [x] forceRefresh gets a new token
- [x] clear() removes all cached tokens
- [x] CutiEClient adds Authorization header to all requests
- [x] CutiEClient retries once on 401
- [x] CutiEClient throws on second 401 (no infinite retry)
- [x] CutiEClient handles JSON responses
- [x] CutiEClient handles non-JSON responses
- [x] CutiEClient passes query params correctly
- [x] POST/PUT/PATCH send JSON body with Content-Type
- [x] DELETE sends correct method
- [x] formatError/formatSuccess produce valid MCP response objects
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)