### PR TITLE
feat: implement 14 MCP tools for conversation management

### DIFF
--- a/src/tools/analytics.js
+++ b/src/tools/analytics.js
@@ -37,9 +37,21 @@ export const analyticsTools = [
  * Handle an analytics tool call.
  * @param {string} name - Tool name
  * @param {Object} args - Tool arguments
- * @param {import('../api/client.js').CutiEClient} _client - API client
+ * @param {import('../api/client.js').CutiEClient} client - API client
  */
-export async function handleAnalyticsTool(name, _args, _client) {
-  // TODO: Implement in issue #3
-  throw new Error(`Tool ${name} not yet implemented - see issue #3`);
+export async function handleAnalyticsTool(name, args, client) {
+  switch (name) {
+    case "get_conversation_stats": {
+      const params = {};
+      if (args.days !== undefined) params.days = args.days;
+      return client.get("/v1/analytics/conversation-stats", params);
+    }
+    case "get_response_times": {
+      const params = {};
+      if (args.days !== undefined) params.days = args.days;
+      return client.get("/v1/analytics/response-times", params);
+    }
+    default:
+      throw new Error(`Unknown analytics tool: ${name}`);
+  }
 }

--- a/src/tools/canned-responses.js
+++ b/src/tools/canned-responses.js
@@ -63,9 +63,23 @@ export const cannedResponseTools = [
  * Handle a canned response tool call.
  * @param {string} name - Tool name
  * @param {Object} args - Tool arguments
- * @param {import('../api/client.js').CutiEClient} _client - API client
+ * @param {import('../api/client.js').CutiEClient} client - API client
  */
-export async function handleCannedResponseTool(name, _args, _client) {
-  // TODO: Implement in issue #3
-  throw new Error(`Tool ${name} not yet implemented - see issue #3`);
+export async function handleCannedResponseTool(name, args, client) {
+  switch (name) {
+    case "list_canned_responses":
+      return client.get("/v1/canned-responses");
+    case "create_canned_response": {
+      const body = { title: args.title, content: args.content };
+      if (args.category) body.category = args.category;
+      return client.post("/v1/canned-responses", body);
+    }
+    case "use_canned_response":
+      return client.post(
+        `/v1/conversations/${args.conversation_id}/canned-responses/${args.canned_response_id}/use`,
+        { variables: args.variables || {} }
+      );
+    default:
+      throw new Error(`Unknown canned response tool: ${name}`);
+  }
 }

--- a/src/tools/conversations.js
+++ b/src/tools/conversations.js
@@ -96,9 +96,32 @@ export const conversationTools = [
  * Handle a conversation tool call.
  * @param {string} name - Tool name
  * @param {Object} args - Tool arguments
- * @param {import('../api/client.js').CutiEClient} _client - API client
+ * @param {import('../api/client.js').CutiEClient} client - API client
  */
-export async function handleConversationTool(name, _args, _client) {
-  // TODO: Implement in issue #3
-  throw new Error(`Tool ${name} not yet implemented - see issue #3`);
+export async function handleConversationTool(name, args, client) {
+  switch (name) {
+    case "list_conversations": {
+      const params = {};
+      if (args.status) params.status = args.status;
+      if (args.category) params.category = args.category;
+      if (args.limit !== undefined) params.limit = args.limit;
+      if (args.offset !== undefined) params.offset = args.offset;
+      return client.get("/v1/conversations", params);
+    }
+    case "get_conversation":
+      return client.get(`/v1/conversations/${args.conversation_id}`);
+    case "update_conversation": {
+      const body = {};
+      if (args.status) body.status = args.status;
+      if (args.priority) body.priority = args.priority;
+      if (args.category) body.category = args.category;
+      return client.patch(`/v1/conversations/${args.conversation_id}`, body);
+    }
+    case "assign_conversation":
+      return client.post(`/v1/conversations/${args.conversation_id}/assign`, {
+        admin_id: args.admin_id || null,
+      });
+    default:
+      throw new Error(`Unknown conversation tool: ${name}`);
+  }
 }

--- a/src/tools/messages.js
+++ b/src/tools/messages.js
@@ -51,9 +51,21 @@ export const messageTools = [
  * Handle a message tool call.
  * @param {string} name - Tool name
  * @param {Object} args - Tool arguments
- * @param {import('../api/client.js').CutiEClient} _client - API client
+ * @param {import('../api/client.js').CutiEClient} client - API client
  */
-export async function handleMessageTool(name, _args, _client) {
-  // TODO: Implement in issue #3
-  throw new Error(`Tool ${name} not yet implemented - see issue #3`);
+export async function handleMessageTool(name, args, client) {
+  switch (name) {
+    case "send_message":
+      return client.post(`/v1/conversations/${args.conversation_id}/messages`, {
+        message: args.message,
+        internal_note: args.internal_note || false,
+      });
+    case "list_messages": {
+      const params = {};
+      if (args.limit !== undefined) params.limit = args.limit;
+      return client.get(`/v1/conversations/${args.conversation_id}/messages`, params);
+    }
+    default:
+      throw new Error(`Unknown message tool: ${name}`);
+  }
 }

--- a/src/tools/tags.js
+++ b/src/tools/tags.js
@@ -55,9 +55,21 @@ export const tagTools = [
  * Handle a tag tool call.
  * @param {string} name - Tool name
  * @param {Object} args - Tool arguments
- * @param {import('../api/client.js').CutiEClient} _client - API client
+ * @param {import('../api/client.js').CutiEClient} client - API client
  */
-export async function handleTagTool(name, _args, _client) {
-  // TODO: Implement in issue #3
-  throw new Error(`Tool ${name} not yet implemented - see issue #3`);
+export async function handleTagTool(name, args, client) {
+  switch (name) {
+    case "list_tags":
+      return client.get("/v1/tags");
+    case "add_tag":
+      return client.post(`/v1/conversations/${args.conversation_id}/tags`, {
+        tag: args.tag,
+      });
+    case "remove_tag":
+      return client.delete(
+        `/v1/conversations/${args.conversation_id}/tags/${encodeURIComponent(args.tag)}`
+      );
+    default:
+      throw new Error(`Unknown tag tool: ${name}`);
+  }
 }

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleAnalyticsTool } from "../src/tools/analytics.js";
+
+function mockClient() {
+  return {
+    get: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+describe("handleAnalyticsTool", () => {
+  describe("get_conversation_stats", () => {
+    it("should call GET with no params by default", async () => {
+      const client = mockClient();
+      await handleAnalyticsTool("get_conversation_stats", {}, client);
+      expect(client.get).toHaveBeenCalledWith(
+        "/v1/analytics/conversation-stats",
+        {}
+      );
+    });
+
+    it("should pass days param", async () => {
+      const client = mockClient();
+      await handleAnalyticsTool("get_conversation_stats", { days: 7 }, client);
+      expect(client.get).toHaveBeenCalledWith(
+        "/v1/analytics/conversation-stats",
+        { days: 7 }
+      );
+    });
+  });
+
+  describe("get_response_times", () => {
+    it("should call GET with no params by default", async () => {
+      const client = mockClient();
+      await handleAnalyticsTool("get_response_times", {}, client);
+      expect(client.get).toHaveBeenCalledWith(
+        "/v1/analytics/response-times",
+        {}
+      );
+    });
+
+    it("should pass days param", async () => {
+      const client = mockClient();
+      await handleAnalyticsTool("get_response_times", { days: 90 }, client);
+      expect(client.get).toHaveBeenCalledWith(
+        "/v1/analytics/response-times",
+        { days: 90 }
+      );
+    });
+  });
+
+  it("should throw on unknown tool", async () => {
+    const client = mockClient();
+    await expect(
+      handleAnalyticsTool("unknown_tool", {}, client)
+    ).rejects.toThrow("Unknown analytics tool: unknown_tool");
+  });
+
+  it("should propagate client errors", async () => {
+    const client = mockClient();
+    client.get.mockRejectedValue(new Error("Timeout"));
+    await expect(
+      handleAnalyticsTool("get_conversation_stats", {}, client)
+    ).rejects.toThrow("Timeout");
+  });
+});

--- a/test/canned-responses.test.js
+++ b/test/canned-responses.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleCannedResponseTool } from "../src/tools/canned-responses.js";
+
+function mockClient() {
+  return {
+    get: vi.fn().mockResolvedValue({ ok: true }),
+    post: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+describe("handleCannedResponseTool", () => {
+  describe("list_canned_responses", () => {
+    it("should call GET /v1/canned-responses", async () => {
+      const client = mockClient();
+      await handleCannedResponseTool("list_canned_responses", {}, client);
+      expect(client.get).toHaveBeenCalledWith("/v1/canned-responses");
+    });
+  });
+
+  describe("create_canned_response", () => {
+    it("should call POST with title and content", async () => {
+      const client = mockClient();
+      await handleCannedResponseTool("create_canned_response", {
+        title: "Greeting",
+        content: "Hello {{name}}, how can I help?",
+      }, client);
+      expect(client.post).toHaveBeenCalledWith("/v1/canned-responses", {
+        title: "Greeting",
+        content: "Hello {{name}}, how can I help?",
+      });
+    });
+
+    it("should include category when provided", async () => {
+      const client = mockClient();
+      await handleCannedResponseTool("create_canned_response", {
+        title: "Bug Ack",
+        content: "Thanks for reporting this bug.",
+        category: "bugs",
+      }, client);
+      expect(client.post).toHaveBeenCalledWith("/v1/canned-responses", {
+        title: "Bug Ack",
+        content: "Thanks for reporting this bug.",
+        category: "bugs",
+      });
+    });
+  });
+
+  describe("use_canned_response", () => {
+    it("should call POST /use with variables", async () => {
+      const client = mockClient();
+      await handleCannedResponseTool("use_canned_response", {
+        conversation_id: "conv_123",
+        canned_response_id: "cr_456",
+        variables: { name: "John" },
+      }, client);
+      expect(client.post).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/canned-responses/cr_456/use",
+        { variables: { name: "John" } }
+      );
+    });
+
+    it("should send empty variables when not provided", async () => {
+      const client = mockClient();
+      await handleCannedResponseTool("use_canned_response", {
+        conversation_id: "conv_123",
+        canned_response_id: "cr_456",
+      }, client);
+      expect(client.post).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/canned-responses/cr_456/use",
+        { variables: {} }
+      );
+    });
+  });
+
+  it("should throw on unknown tool", async () => {
+    const client = mockClient();
+    await expect(
+      handleCannedResponseTool("unknown_tool", {}, client)
+    ).rejects.toThrow("Unknown canned response tool: unknown_tool");
+  });
+
+  it("should propagate client errors", async () => {
+    const client = mockClient();
+    client.get.mockRejectedValue(new Error("Forbidden"));
+    await expect(
+      handleCannedResponseTool("list_canned_responses", {}, client)
+    ).rejects.toThrow("Forbidden");
+  });
+});

--- a/test/conversations.test.js
+++ b/test/conversations.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleConversationTool } from "../src/tools/conversations.js";
+
+function mockClient() {
+  return {
+    get: vi.fn().mockResolvedValue({ ok: true }),
+    post: vi.fn().mockResolvedValue({ ok: true }),
+    patch: vi.fn().mockResolvedValue({ ok: true }),
+    delete: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+describe("handleConversationTool", () => {
+  describe("list_conversations", () => {
+    it("should call GET /v1/conversations with no params", async () => {
+      const client = mockClient();
+      await handleConversationTool("list_conversations", {}, client);
+      expect(client.get).toHaveBeenCalledWith("/v1/conversations", {});
+    });
+
+    it("should pass status and category filters", async () => {
+      const client = mockClient();
+      await handleConversationTool("list_conversations", {
+        status: "open",
+        category: "bug",
+      }, client);
+      expect(client.get).toHaveBeenCalledWith("/v1/conversations", {
+        status: "open",
+        category: "bug",
+      });
+    });
+
+    it("should pass pagination params", async () => {
+      const client = mockClient();
+      await handleConversationTool("list_conversations", {
+        limit: 10,
+        offset: 20,
+      }, client);
+      expect(client.get).toHaveBeenCalledWith("/v1/conversations", {
+        limit: 10,
+        offset: 20,
+      });
+    });
+
+    it("should pass limit=0 correctly", async () => {
+      const client = mockClient();
+      await handleConversationTool("list_conversations", { limit: 0 }, client);
+      expect(client.get).toHaveBeenCalledWith("/v1/conversations", { limit: 0 });
+    });
+  });
+
+  describe("get_conversation", () => {
+    it("should call GET /v1/conversations/:id", async () => {
+      const client = mockClient();
+      await handleConversationTool("get_conversation", {
+        conversation_id: "conv_123",
+      }, client);
+      expect(client.get).toHaveBeenCalledWith("/v1/conversations/conv_123");
+    });
+  });
+
+  describe("update_conversation", () => {
+    it("should call PATCH with status", async () => {
+      const client = mockClient();
+      await handleConversationTool("update_conversation", {
+        conversation_id: "conv_123",
+        status: "resolved",
+      }, client);
+      expect(client.patch).toHaveBeenCalledWith("/v1/conversations/conv_123", {
+        status: "resolved",
+      });
+    });
+
+    it("should call PATCH with multiple fields", async () => {
+      const client = mockClient();
+      await handleConversationTool("update_conversation", {
+        conversation_id: "conv_123",
+        status: "in_progress",
+        priority: "high",
+        category: "bug",
+      }, client);
+      expect(client.patch).toHaveBeenCalledWith("/v1/conversations/conv_123", {
+        status: "in_progress",
+        priority: "high",
+        category: "bug",
+      });
+    });
+
+    it("should send empty body when no update fields provided", async () => {
+      const client = mockClient();
+      await handleConversationTool("update_conversation", {
+        conversation_id: "conv_123",
+      }, client);
+      expect(client.patch).toHaveBeenCalledWith("/v1/conversations/conv_123", {});
+    });
+  });
+
+  describe("assign_conversation", () => {
+    it("should call POST /assign with admin_id", async () => {
+      const client = mockClient();
+      await handleConversationTool("assign_conversation", {
+        conversation_id: "conv_123",
+        admin_id: "admin_456",
+      }, client);
+      expect(client.post).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/assign",
+        { admin_id: "admin_456" }
+      );
+    });
+
+    it("should send null admin_id to unassign", async () => {
+      const client = mockClient();
+      await handleConversationTool("assign_conversation", {
+        conversation_id: "conv_123",
+      }, client);
+      expect(client.post).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/assign",
+        { admin_id: null }
+      );
+    });
+  });
+
+  it("should throw on unknown tool", async () => {
+    const client = mockClient();
+    await expect(
+      handleConversationTool("unknown_tool", {}, client)
+    ).rejects.toThrow("Unknown conversation tool: unknown_tool");
+  });
+
+  it("should propagate client errors", async () => {
+    const client = mockClient();
+    client.get.mockRejectedValue(new Error("Network error"));
+    await expect(
+      handleConversationTool("list_conversations", {}, client)
+    ).rejects.toThrow("Network error");
+  });
+});

--- a/test/messages.test.js
+++ b/test/messages.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleMessageTool } from "../src/tools/messages.js";
+
+function mockClient() {
+  return {
+    get: vi.fn().mockResolvedValue({ ok: true }),
+    post: vi.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+describe("handleMessageTool", () => {
+  describe("send_message", () => {
+    it("should call POST with message content", async () => {
+      const client = mockClient();
+      await handleMessageTool("send_message", {
+        conversation_id: "conv_123",
+        message: "Hello there",
+      }, client);
+      expect(client.post).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/messages",
+        { message: "Hello there", internal_note: false }
+      );
+    });
+
+    it("should pass internal_note flag", async () => {
+      const client = mockClient();
+      await handleMessageTool("send_message", {
+        conversation_id: "conv_123",
+        message: "Internal note",
+        internal_note: true,
+      }, client);
+      expect(client.post).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/messages",
+        { message: "Internal note", internal_note: true }
+      );
+    });
+  });
+
+  describe("list_messages", () => {
+    it("should call GET messages with no params", async () => {
+      const client = mockClient();
+      await handleMessageTool("list_messages", {
+        conversation_id: "conv_123",
+      }, client);
+      expect(client.get).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/messages",
+        {}
+      );
+    });
+
+    it("should pass limit param", async () => {
+      const client = mockClient();
+      await handleMessageTool("list_messages", {
+        conversation_id: "conv_123",
+        limit: 10,
+      }, client);
+      expect(client.get).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/messages",
+        { limit: 10 }
+      );
+    });
+  });
+
+  it("should throw on unknown tool", async () => {
+    const client = mockClient();
+    await expect(
+      handleMessageTool("unknown_tool", {}, client)
+    ).rejects.toThrow("Unknown message tool: unknown_tool");
+  });
+
+  it("should propagate client errors", async () => {
+    const client = mockClient();
+    client.post.mockRejectedValue(new Error("Server error"));
+    await expect(
+      handleMessageTool("send_message", {
+        conversation_id: "conv_123",
+        message: "test",
+      }, client)
+    ).rejects.toThrow("Server error");
+  });
+});

--- a/test/tags.test.js
+++ b/test/tags.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { handleTagTool } from "../src/tools/tags.js";
+
+function mockClient() {
+  return {
+    get: vi.fn().mockResolvedValue({ ok: true }),
+    post: vi.fn().mockResolvedValue({ ok: true }),
+    delete: vi.fn().mockResolvedValue(null),
+  };
+}
+
+describe("handleTagTool", () => {
+  describe("list_tags", () => {
+    it("should call GET /v1/tags", async () => {
+      const client = mockClient();
+      await handleTagTool("list_tags", {}, client);
+      expect(client.get).toHaveBeenCalledWith("/v1/tags");
+    });
+  });
+
+  describe("add_tag", () => {
+    it("should call POST with tag name", async () => {
+      const client = mockClient();
+      await handleTagTool("add_tag", {
+        conversation_id: "conv_123",
+        tag: "urgent",
+      }, client);
+      expect(client.post).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/tags",
+        { tag: "urgent" }
+      );
+    });
+  });
+
+  describe("remove_tag", () => {
+    it("should call DELETE with encoded tag name", async () => {
+      const client = mockClient();
+      await handleTagTool("remove_tag", {
+        conversation_id: "conv_123",
+        tag: "urgent",
+      }, client);
+      expect(client.delete).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/tags/urgent"
+      );
+    });
+
+    it("should encode special characters in tag name", async () => {
+      const client = mockClient();
+      await handleTagTool("remove_tag", {
+        conversation_id: "conv_123",
+        tag: "needs review",
+      }, client);
+      expect(client.delete).toHaveBeenCalledWith(
+        "/v1/conversations/conv_123/tags/needs%20review"
+      );
+    });
+  });
+
+  it("should throw on unknown tool", async () => {
+    const client = mockClient();
+    await expect(
+      handleTagTool("unknown_tool", {}, client)
+    ).rejects.toThrow("Unknown tag tool: unknown_tool");
+  });
+
+  it("should propagate client errors", async () => {
+    const client = mockClient();
+    client.get.mockRejectedValue(new Error("Not found"));
+    await expect(
+      handleTagTool("list_tags", {}, client)
+    ).rejects.toThrow("Not found");
+  });
+});


### PR DESCRIPTION
## Summary

- Implement all 14 tool handlers across 5 domain files (conversations, messages, tags, analytics, canned responses)
- Each handler routes to the correct Cuti-E API endpoint via `CutiEClient`
- 37 new handler tests covering correct API paths, parameter passing, pagination, error propagation, and edge cases
- 78 total tests pass, lint clean

## Tools Implemented

| Domain | Tools | Endpoints |
|--------|-------|-----------|
| Conversations | `list_conversations`, `get_conversation`, `update_conversation`, `assign_conversation` | GET/PATCH/POST `/v1/conversations` |
| Messages | `send_message`, `list_messages` | POST/GET `/v1/conversations/:id/messages` |
| Tags | `list_tags`, `add_tag`, `remove_tag` | GET `/v1/tags`, POST/DELETE `/v1/conversations/:id/tags` |
| Analytics | `get_conversation_stats`, `get_response_times` | GET `/v1/analytics/*` |
| Canned Responses | `list_canned_responses`, `create_canned_response`, `use_canned_response` | GET/POST `/v1/canned-responses` |

## Test plan

- [x] All 78 tests pass (`npm test`)
- [x] ESLint clean (`npm run lint`)
- [ ] E2E testing with live API (issue #4)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)